### PR TITLE
Add user-frontend and brief-responses frontend to log streamer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install -r requirements.txt
 The `config.yaml` file defines what metrics are to be shipped to graphite. It is generated from the `config.yaml.j2` Jinja template using:
 
 ```
-plumbum config.yaml.j2 ec2 > config.yaml
+AWS_PROFILE='<profile name for dev infrastructure>' aws-auth plumbum config.yaml.j2 ec2 > config.yaml
 ```
 
 ## To run locally

--- a/config.yaml.j2
+++ b/config.yaml.j2
@@ -1,4 +1,4 @@
-{% set apps = ["api", "admin-frontend", "briefs-frontend", "buyer-frontend", "nginx", "search-api", "supplier-frontend"] -%}
+{% set apps = ["api", "admin-frontend", "briefs-frontend", "brief-responses-frontend", "buyer-frontend", "nginx", "search-api", "supplier-frontend", "user-frontend"] -%}
 {% set environments = ["preview", "staging", "production"] -%}
 Auth:
   region: "eu-west-1"


### PR DESCRIPTION
## Summary
Logs from the user-frontend and brief-responses-frontend weren't being streamed from CloudWatch to HostedGraphite. This adds those apps and a little detail to the readme.

## Ticket
https://trello.com/c/lAZgnrSn/19-add-brief-responses-frontend-and-user-frontend-to-grafana