### PR TITLE
Replace nginx metrics with router metrics

### DIFF
--- a/config.yaml.j2
+++ b/config.yaml.j2
@@ -1,4 +1,4 @@
-{% set apps = ["api", "admin-frontend", "briefs-frontend", "brief-responses-frontend", "buyer-frontend", "nginx", "search-api", "supplier-frontend", "user-frontend"] -%}
+{% set apps = ["api", "admin-frontend", "briefs-frontend", "brief-responses-frontend", "buyer-frontend", "router", "search-api", "supplier-frontend", "user-frontend"] -%}
 {% set environments = ["preview", "staging", "production"] -%}
 Auth:
   region: "eu-west-1"


### PR DESCRIPTION
As we have replaced our previous AWS nginx infrastructure with
a new router app.