### PR TITLE
Send router 429s metric to hosted graphite

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,9 +31,11 @@ def initialize_metrics():
     with open('config.yaml') as fp:
         config = yaml.load(fp)
         for metric in config['Metrics']:
-            metric_name = (metric['Options']['Formatter']
-                           .replace("%(statistic)s", metric['Statistics'].lower()))
-            initialized_metrics.append("{} 0.0 {}".format(metric_name, timestamp))
+            stats = metric['Statistics'] if isinstance(metric['Statistics'], list) else [metric['Statistics']]
+            for stat in stats:
+                metric_name = (metric['Options']['Formatter']
+                               .replace("%(statistic)s", stat.lower()))
+                initialized_metrics.append("{} 0.0 {}".format(metric_name, timestamp))
     send_to_hostedgraphite("\n".join(initialized_metrics))
 
 

--- a/config.yaml.j2
+++ b/config.yaml.j2
@@ -8,7 +8,7 @@ Metrics:
 {% for bucket in range(10) -%}
 - Namespace: "DM-RequestTimeBuckets"
   MetricName: "{{ environment }}-{{ app }}-request-times-{{ bucket }}"
-  Statistics: "SampleCount"
+  Statistics: ["SampleCount", "Sum"]
   Dimensions: []
   Options:
     Formatter: 'cloudwatch.request_time_buckets.{{ environment }}.{{ app }}.request_time_bucket_{{ bucket }}.%(statistic)s'
@@ -19,7 +19,7 @@ Metrics:
 {% for app in apps -%}
 - Namespace: "DM-500s"
   MetricName: "{{ environment }}{% if app != "nginx" %}-{{ app }}{% endif %}-nginx-500s"
-  Statistics: "SampleCount"
+  Statistics: ["SampleCount", "Sum"]
   Dimensions: []
   Options:
     Formatter: 'cloudwatch.application_500s.{{ environment }}.{{ app }}.500s.%(statistic)s'

--- a/config.yaml.j2
+++ b/config.yaml.j2
@@ -25,5 +25,13 @@ Metrics:
     Formatter: 'cloudwatch.application_500s.{{ environment }}.{{ app }}.500s.%(statistic)s'
 {% endfor -%}
 {% endfor -%}
+{% for environment in environments -%}
+- Namespace: "DM-429s"
+  MetricName: "{{ environment }}-router-nginx-429s"
+  Statistics: "Sum"
+  Dimensions: []
+  Options:
+    Formatter: "cloudwatch.router_429s.{{ environment }}.router.429s.%(statistic)s"
+{% endfor -%}
 Options:
   Count: 10


### PR DESCRIPTION
If we introduce rate limiting we'll be returning 429s for requests that
have been dropped.

~~We're not going to send the 429 logs to Kibana (we'll filter them out in
the lambda subscription filter), as one of the reasons we're introducing
IP rate limiting is due to the mad amount of logs we were generating
while being crawled. So we need a way to monitor the number of 429s
we're getting.~~
We are going to send them for a bit. So we have better visibility on the
what's happening with 429's. We can then drop them when we're happy.

A metric has been set up in cloudwatch for the count of 429s, so we can
ship it to hosted graphite and display it on the dashboard, or set up
alerting for it.

This also starts sending the `sum` statistic, as well as the `samplecount`.
We currently only send the `samplecount` which is just the number datapoints
in a given period. This is fine, but we'd like to start using a default value
for the metrics. This way, if, say, we don't get any 500's, a value of 0 will be
sent instead of nothing at all. This will prevent patchy data. The issue is
that sending a value of 0 is the same as sending a value 1 when looking at
the `samplecount` statistic. If we want to use a default value, we need to start
using the `sum` statistic. Sending both statistics for a while will allow a
smooth transition.

This is what this PR is for.