### PR TITLE
Remove `samplecount` from statistics being sent

### DIFF
--- a/config.yaml.j2
+++ b/config.yaml.j2
@@ -8,7 +8,7 @@ Metrics:
 {% for bucket in range(10) -%}
 - Namespace: "DM-RequestTimeBuckets"
   MetricName: "{{ environment }}-{{ app }}-request-times-{{ bucket }}"
-  Statistics: ["SampleCount", "Sum"]
+  Statistics: "Sum"
   Dimensions: []
   Options:
     Formatter: 'cloudwatch.request_time_buckets.{{ environment }}.{{ app }}.request_time_bucket_{{ bucket }}.%(statistic)s'
@@ -19,7 +19,7 @@ Metrics:
 {% for app in apps -%}
 - Namespace: "DM-500s"
   MetricName: "{{ environment }}{% if app != "nginx" %}-{{ app }}{% endif %}-nginx-500s"
-  Statistics: ["SampleCount", "Sum"]
+  Statistics: "Sum"
   Dimensions: []
   Options:
     Formatter: 'cloudwatch.application_500s.{{ environment }}.{{ app }}.500s.%(statistic)s'


### PR DESCRIPTION
The Grafana dashboards and all the alerts in Hosted Graphite are now
using the `sum` statistic instead of `samplecount`. We no longer need to
send it.