### PR TITLE
Bump Python version and add some logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python
 import os
 import subprocess
+import logging
 from datetime import datetime, timedelta
 
 import requests
 import yaml
 from retrying import retry
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s — %(levelname)s — %(message)s",
+)
 
 
 def get_timestamp():
@@ -22,7 +28,9 @@ def send_to_hostedgraphite(metrics):
     )
 
     if response.status_code >= 400:
-        print(response.status_code, ": Error sending metrics to hosted graphite")
+        logging.warn(f"Error sending metrics to hosted graphite - Status code {response.status_code}")
+    else:
+        logging.info(f"Metrics sent to hosted graphite - Status code {response.status_code}")
 
 
 def initialize_metrics():

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.4.6
+python-3.6.5


### PR DESCRIPTION
In response to [this 2nd line ticket.](https://trello.com/c/9OcJ1lMW)

PaaS no longer support Python 3.4 and we should really move to the
latest version.

Also adds a bit of logging. Otherwise it's very hard to tell if the app
is actually doing something when running.