### PR TITLE
Ship apiclient retries metric to hosted graphite

### DIFF
--- a/config.yaml.j2
+++ b/config.yaml.j2
@@ -24,6 +24,12 @@ Metrics:
   Dimensions: []
   Options:
     Formatter: 'cloudwatch.application_500s.{{ environment }}.{{ app }}.500s.%(statistic)s'
+- Namespace: "DM-APIClient-Retries"
+  MetricName: "{{ environment }}-{{ app }}-apiclient-retries"
+  Statistics: "Sum"
+  Dimensions: []
+  Options:
+    Formatter: "cloudwatch.apiclient_retries.{{ environment }}.{{ app }}.retries.%(statistic)s"
 {% endfor -%}
 {% endfor -%}
 {% for environment in environments -%}


### PR DESCRIPTION
We have a new metric in cloudwatch that tracks the number of retries the
apiclient makes for different apps. We can ship it to Hosted Graphite so
we can monitor it.