### PR TITLE
Add .cfignore file to stop cloudfoundry uploading developer venvs

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,11 @@
+*
+
+# Required for setting up environment
+!runtime.txt
+!requirements.txt
+
+# App requirements
+!app.py
+!pipe-watchdog.py
+!config.yaml
+


### PR DESCRIPTION
The app itself 
doesn't require the:
* scripts dir
* config.yaml.example
* config.yaml.j2
* manifest.yml.example

and breaks with:
* venv dir


https://trello.com/c/xnmJdJdH/154-stop-cloudfoundry-uploading-and-using-developer-virtualenvs