### PR TITLE
This example command is no longer relevant.

### DIFF
--- a/manifest.yml.example
+++ b/manifest.yml.example
@@ -15,7 +15,7 @@ applications:
     buildpack: python_buildpack
     no-route: true
     health-check-type: none
-    command: python app.py 2>&1 | python pipe-watchdog.py
+    command: python app.py
     instances: 1
     memory: 128M
     env:


### PR DESCRIPTION

Removing this was missed as part of the app refactor. 
The watchdog script no longer exists.
